### PR TITLE
[Fix] addTryCatch (#23)

### DIFF
--- a/cds-server/src/controller/moodboardController.ts
+++ b/cds-server/src/controller/moodboardController.ts
@@ -25,6 +25,8 @@ const updateMoodboard = async ( req: Request, res: Response ) => {
 
     if(!updateMoodboard)
             return res.status(sc.MB_PATCH_FAIL).send(fail(sc.MB_PATCH_FAIL, rm.MB_PATCH_FAIL));
+    if(updateMoodboard == rm.INTERNAL_SERVER_ERROR)
+    return res.status(sc.INTERNAL_SERVER_ERROR).send(fail(sc.INTERNAL_SERVER_ERROR, rm.INTERNAL_SERVER_ERROR))
 
     return res.status(sc.OK).send(success(sc.OK, rm.MB_PATCH_SUCCESS));
 }

--- a/cds-server/src/service/moodboardService.ts
+++ b/cds-server/src/service/moodboardService.ts
@@ -1,6 +1,9 @@
 import { MoodboardPatchDTO } from './../interfaces/moodboard/MoodboardPatchDTO';
 const { PrismaClient } = require("@prisma/client");
 const prisma = new PrismaClient();
+import { rm, sc } from "../constants"
+import { fail } from  "../constants/response"
+import { Response } from "express";
 
 //*  무드보드 전체 조회
 const getAllMoodboard = async () => {
@@ -20,15 +23,21 @@ const getAllMoodboard = async () => {
 }
 
 const updateMoodboard = async (MoodboardPatchDTO: MoodboardPatchDTO) => {
-    const data = await prisma.moodboard.update({
-        where: {
-            id: MoodboardPatchDTO.id
-        },
-        data: {
-            is_public: MoodboardPatchDTO.is_public
-        }
-    });
-    return data;
+    try {
+        const data = await prisma.moodboard.update({
+            where: {
+                id: MoodboardPatchDTO.id
+            },
+            data: {
+                is_public: MoodboardPatchDTO.is_public
+            }
+        });
+        return data;
+    } catch(error) {
+        console.log(error);
+        //throw error;
+        return rm.INTERNAL_SERVER_ERROR
+    }
 }
 
 const moodboardService = {


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number를 적어주세요 -->
closed #23 

## 변경사항
`moodboardService.ts` 에서, 무드보드 편집 API의 오류를 잡기 위해 try-catch문을 추가해주었습니다.

## 참고사항
catch에서 Invalid Server Error 라는 상수값을 넘겨주고, Controller에서 해당 상수값이 넘어왔을 경우에 대한 오류 메시지 출력을 처리합니다.
